### PR TITLE
Updated dependencies for client build

### DIFF
--- a/cmd/gollama/gpuinfo.go
+++ b/cmd/gollama/gpuinfo.go
@@ -1,3 +1,5 @@
+//go:build !client
+
 package main
 
 import (

--- a/cmd/gollama/main.go
+++ b/cmd/gollama/main.go
@@ -55,7 +55,6 @@ type Globals struct {
 
 type CLI struct {
 	Globals
-	GpuInfo GpuInfoCmd `cmd:"" name:"gpuinfo" help:"Show GPU information"`
 	ModelCommands
 	CompletionCommands
 	EmbedCommands

--- a/cmd/gollama/server.go
+++ b/cmd/gollama/server.go
@@ -25,7 +25,8 @@ import (
 // TYPES
 
 type ServerCommands struct {
-	RunServer RunServer `cmd:"" name:"run" help:"Run server." group:"SERVER"`
+	GpuInfo   GpuInfoCmd `cmd:"" name:"gpuinfo" help:"Show GPU information"`
+	RunServer RunServer  `cmd:"" name:"run" help:"Run server." group:"SERVER"`
 }
 
 type RunServer struct {

--- a/cmd/gollama/tokenizer.go
+++ b/cmd/gollama/tokenizer.go
@@ -6,8 +6,10 @@ import (
 	// Packages
 	otel "github.com/mutablelogic/go-client/pkg/otel"
 	httpclient "github.com/mutablelogic/go-llama/pkg/llamacpp/httpclient"
-	llamacpp "github.com/mutablelogic/go-llama/sys/llamacpp"
 )
+
+// Token is a token ID (alias for int32 to match llamacpp.Token)
+type Token = int32
 
 ///////////////////////////////////////////////////////////////////////////////
 // TYPES
@@ -25,10 +27,10 @@ type TokenizeCommand struct {
 }
 
 type DetokenizeCommand struct {
-	Model          string           `arg:"" name:"model" help:"Model name or path"`
-	Tokens         []llamacpp.Token `arg:"" name:"tokens" help:"Tokens to detokenize"`
-	RemoveSpecial  *bool            `name:"remove-special" help:"Remove BOS/EOS tokens"`
-	UnparseSpecial *bool            `name:"unparse-special" help:"Render special tokens as text"`
+	Model          string  `arg:"" name:"model" help:"Model name or path"`
+	Tokens         []Token `arg:"" name:"tokens" help:"Tokens to detokenize"`
+	RemoveSpecial  *bool   `name:"remove-special" help:"Remove BOS/EOS tokens"`
+	UnparseSpecial *bool   `name:"unparse-special" help:"Render special tokens as text"`
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/pkg/llamacpp/schema/model.go
+++ b/pkg/llamacpp/schema/model.go
@@ -1,10 +1,5 @@
 package schema
 
-import (
-	// Packges
-	gguf "github.com/mutablelogic/go-llama/sys/gguf"
-)
-
 ///////////////////////////////////////////////////////////////////////////////
 // TYPES
 
@@ -39,61 +34,6 @@ type ModelRuntime struct {
 	NCtxTrain int32  `json:"contextSize,omitempty"`
 	NParams   uint64 `json:"paramCount,omitempty"`
 	ModelSize uint64 `json:"modelSizeBytes,omitempty"`
-}
-
-///////////////////////////////////////////////////////////////////////////////
-// CONSTRUCTORS
-
-// NewModelFromGGUF builds a schema Model from a GGUF file context.
-// The relPath is the relative path from basePath to the model file.
-// This is a lightweight way to get model metadata without loading the full model.
-func NewModelFromGGUF(basePath, relPath string, ctx *gguf.Context) (*Model, error) {
-	if ctx == nil {
-		return nil, gguf.ErrInvalidContext
-	}
-
-	arch := ctx.Architecture()
-	meta, err := ctx.AllMetadata()
-	if err != nil {
-		return nil, err
-	}
-
-	model := &Model{
-		Path:          relPath,
-		Name:          ctx.Name(),
-		Architecture:  arch,
-		Description:   ctx.Description(),
-		ChatTemplate:  ctx.ChatTemplate(),
-		ContextSize:   getInt32(meta, arch+".context_length"),
-		EmbeddingSize: getInt32(meta, arch+".embedding_length"),
-		LayerCount:    getInt32(meta, arch+".block_count"),
-		HeadCount:     getInt32(meta, arch+".attention.head_count"),
-		HeadKVCount:   getInt32(meta, arch+".attention.head_count_kv"),
-		Meta:          meta,
-	}
-
-	return model, nil
-}
-
-///////////////////////////////////////////////////////////////////////////////
-// PRIVATE HELPERS
-
-func getInt32(meta map[string]any, key string) int32 {
-	if v, ok := meta[key]; ok {
-		switch val := v.(type) {
-		case int32:
-			return val
-		case uint32:
-			return int32(val)
-		case int64:
-			return int32(val)
-		case uint64:
-			return int32(val)
-		case int:
-			return int32(val)
-		}
-	}
-	return 0
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/pkg/llamacpp/schema/model_gguf.go
+++ b/pkg/llamacpp/schema/model_gguf.go
@@ -1,0 +1,63 @@
+//go:build !client
+
+package schema
+
+import (
+	// Packages
+	gguf "github.com/mutablelogic/go-llama/sys/gguf"
+)
+
+///////////////////////////////////////////////////////////////////////////////
+// CONSTRUCTORS
+
+// NewModelFromGGUF builds a schema Model from a GGUF file context.
+// The relPath is the relative path from basePath to the model file.
+// This is a lightweight way to get model metadata without loading the full model.
+func NewModelFromGGUF(basePath, relPath string, ctx *gguf.Context) (*Model, error) {
+	if ctx == nil {
+		return nil, gguf.ErrInvalidContext
+	}
+
+	arch := ctx.Architecture()
+	meta, err := ctx.AllMetadata()
+	if err != nil {
+		return nil, err
+	}
+
+	model := &Model{
+		Path:          relPath,
+		Name:          ctx.Name(),
+		Architecture:  arch,
+		Description:   ctx.Description(),
+		ChatTemplate:  ctx.ChatTemplate(),
+		ContextSize:   getInt32(meta, arch+".context_length"),
+		EmbeddingSize: getInt32(meta, arch+".embedding_length"),
+		LayerCount:    getInt32(meta, arch+".block_count"),
+		HeadCount:     getInt32(meta, arch+".attention.head_count"),
+		HeadKVCount:   getInt32(meta, arch+".attention.head_count_kv"),
+		Meta:          meta,
+	}
+
+	return model, nil
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// PRIVATE HELPERS
+
+func getInt32(meta map[string]any, key string) int32 {
+	if v, ok := meta[key]; ok {
+		switch val := v.(type) {
+		case int32:
+			return val
+		case uint32:
+			return int32(val)
+		case int64:
+			return int32(val)
+		case uint64:
+			return int32(val)
+		case int:
+			return int32(val)
+		}
+	}
+	return 0
+}


### PR DESCRIPTION
This pull request refactors code related to model metadata extraction and command structure, with a focus on improving modularity and code organization. The most significant changes involve moving GGUF-specific model logic into a separate file, updating type usage for tokenizer commands, and adjusting command registration for GPU information.

### Model metadata extraction refactor

* Moved the GGUF-specific implementation of `NewModelFromGGUF` and its helper `getInt32` from `pkg/llamacpp/schema/model.go` to a new file `pkg/llamacpp/schema/model_gguf.go`, which is now conditionally built only when not targeting the client (`!client` build tag). This improves separation of concerns and build flexibility. [[1]](diffhunk://#diff-4762718c855dea15882caeac7c93771a145c85e4e5e8e5c3fc7228279f6bce85L44-L98) [[2]](diffhunk://#diff-1218554ee5500224abd7c433a70c8d1c210136a575f64860b87b3166e61d25b4R1-R63)
* Removed the direct import of the GGUF package from `model.go`, further decoupling client and server code.

### Command and type improvements

* Changed the type alias for tokens in `cmd/gollama/tokenizer.go` to use a plain `int32` instead of the external `llamacpp.Token` type, simplifying the detokenization command and reducing dependencies. [[1]](diffhunk://#diff-472a2994b1487f4b157038c2c512b1f4bd34510fc05c42fa708a0fbe8ab67565L9-R13) [[2]](diffhunk://#diff-472a2994b1487f4b157038c2c512b1f4bd34510fc05c42fa708a0fbe8ab67565L29-R31)
* Updated the registration of the `GpuInfoCmd` command so that it is now only available in the server command set and not in the global CLI commands, reflecting a more appropriate command grouping. [[1]](diffhunk://#diff-3b00f54dbe4f4fe377986536b52ca09461dbd741f788a7bd391ead1bef252a0aL58) [[2]](diffhunk://#diff-d6df1ccf66178b1387f598e2697653e87968038be625130d609e8954f08a2a2fR28) [[3]](diffhunk://#diff-abaf0fc94202335d2e2250f77c0dc54489fc5ab35aa902de26bf2f399659618cR1-R2)