### PR TITLE
Continued refactoring for building client

### DIFF
--- a/pkg/llamacpp/httpclient/tokenizer.go
+++ b/pkg/llamacpp/httpclient/tokenizer.go
@@ -7,7 +7,6 @@ import (
 	// Packages
 	client "github.com/mutablelogic/go-client"
 	schema "github.com/mutablelogic/go-llama/pkg/llamacpp/schema"
-	llamacpp "github.com/mutablelogic/go-llama/sys/llamacpp"
 )
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -56,7 +55,7 @@ func (c *Client) Tokenize(ctx context.Context, model, text string, opts ...Opt) 
 // Example:
 //
 //	result, err := client.Detokenize(ctx, "llama-7b", tokens)
-func (c *Client) Detokenize(ctx context.Context, model string, tokens []llamacpp.Token, opts ...Opt) (*schema.DetokenizeResponse, error) {
+func (c *Client) Detokenize(ctx context.Context, model string, tokens []schema.Token, opts ...Opt) (*schema.DetokenizeResponse, error) {
 	if model == "" {
 		return nil, fmt.Errorf("model name cannot be empty")
 	}

--- a/pkg/llamacpp/model.go
+++ b/pkg/llamacpp/model.go
@@ -67,7 +67,9 @@ func (l *Llama) LoadModel(ctx context.Context, req schema.LoadModelRequest) (res
 	cached := &schema.CachedModel{
 		Model:    *model,
 		LoadedAt: time.Now(),
-		Handle:   handle,
+		ServerModel: schema.ServerModel{
+			Handle: handle,
+		},
 	}
 	if info, err := handle.Info(); err == nil {
 		cached.Runtime = &schema.ModelRuntime{

--- a/pkg/llamacpp/schema/load.go
+++ b/pkg/llamacpp/schema/load.go
@@ -1,11 +1,7 @@
 package schema
 
 import (
-	"sync"
 	"time"
-
-	// Packages
-	llamacpp "github.com/mutablelogic/go-llama/sys/llamacpp"
 )
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -26,14 +22,13 @@ type PullModelRequest struct {
 	URL string `json:"url"` // URL to download the model from (supports hf:// and https://)
 }
 
-// CachedModel represents a model that has been loaded into memory.
-// The embedded RWMutex provides thread-safety for operations on this model.
+// CachedModel represents a model loaded in memory.
+// For server builds, it embeds ServerModel which provides the Handle and RWMutex.
 type CachedModel struct {
-	sync.RWMutex
+	ServerModel
 	Model
-	LoadedAt time.Time       `json:"loaded_at,omitzero"`
-	Runtime  *ModelRuntime   `json:"runtime,omitempty"`
-	Handle   *llamacpp.Model `json:"-"`
+	LoadedAt time.Time     `json:"loaded_at,omitzero"`
+	Runtime  *ModelRuntime `json:"runtime,omitempty"`
 }
 
 // ContextRequest contains parameters for creating an inference context.

--- a/pkg/llamacpp/schema/load_client.go
+++ b/pkg/llamacpp/schema/load_client.go
@@ -1,0 +1,9 @@
+//go:build client
+
+package schema
+
+///////////////////////////////////////////////////////////////////////////////
+// TYPES
+
+// ServerModel is a stub for client builds (not used in pure HTTP client).
+type ServerModel struct{}

--- a/pkg/llamacpp/schema/load_server.go
+++ b/pkg/llamacpp/schema/load_server.go
@@ -1,0 +1,20 @@
+//go:build !client
+
+package schema
+
+import (
+	"sync"
+
+	// Packages
+	llamacpp "github.com/mutablelogic/go-llama/sys/llamacpp"
+)
+
+///////////////////////////////////////////////////////////////////////////////
+// TYPES
+
+// ServerModel represents a model loaded in memory on the server.
+// It includes the C model handle and synchronization primitives.
+type ServerModel struct {
+	sync.RWMutex
+	Handle *llamacpp.Model
+}

--- a/pkg/llamacpp/schema/model.go
+++ b/pkg/llamacpp/schema/model.go
@@ -42,3 +42,7 @@ type ModelRuntime struct {
 func (m Model) String() string {
 	return stringify(m)
 }
+
+func (m ModelRuntime) String() string {
+	return stringify(m)
+}

--- a/pkg/llamacpp/schema/tokenizer.go
+++ b/pkg/llamacpp/schema/tokenizer.go
@@ -1,9 +1,7 @@
 package schema
 
-import (
-	// Packages
-	llamacpp "github.com/mutablelogic/go-llama/sys/llamacpp"
-)
+// Token is a token ID (type alias for int32)
+type Token = int32
 
 ///////////////////////////////////////////////////////////////////////////////
 // TYPES
@@ -18,15 +16,15 @@ type TokenizeRequest struct {
 
 // TokenizeResponse contains the result of tokenization.
 type TokenizeResponse struct {
-	Tokens []llamacpp.Token `json:"tokens"`
+	Tokens []Token `json:"tokens"`
 }
 
 // DetokenizeRequest contains parameters for detokenizing tokens.
 type DetokenizeRequest struct {
-	Model          string           `json:"model"`                     // Model name or path (must be loaded)
-	Tokens         []llamacpp.Token `json:"tokens"`                    // Tokens to detokenize
-	RemoveSpecial  *bool            `json:"remove_special,omitempty"`  // Remove BOS/EOS tokens (default: false)
-	UnparseSpecial *bool            `json:"unparse_special,omitempty"` // Render special tokens as text (default: true)
+	Model          string  `json:"model"`                     // Model name or path (must be loaded)
+	Tokens         []Token `json:"tokens"`                    // Tokens to detokenize
+	RemoveSpecial  *bool   `json:"remove_special,omitempty"`  // Remove BOS/EOS tokens (default: false)
+	UnparseSpecial *bool   `json:"unparse_special,omitempty"` // Render special tokens as text (default: true)
 }
 
 // DetokenizeResponse contains the result of detokenization.

--- a/pkg/llamacpp/task.go
+++ b/pkg/llamacpp/task.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	// Packages
-
 	schema "github.com/mutablelogic/go-llama/pkg/llamacpp/schema"
 	llamacpp "github.com/mutablelogic/go-llama/sys/llamacpp"
 )


### PR DESCRIPTION
This pull request refactors how model handles and tokens are represented and managed in the codebase, improving separation between client and server builds and simplifying token type usage. The most significant changes include introducing a new `ServerModel` type to encapsulate server-specific model data and synchronization, and replacing the use of `llamacpp.Token` with a simpler `int32` alias for tokens throughout the schema.

**Model and server build separation:**
- Introduced a new `ServerModel` type, which encapsulates the model handle and synchronization primitives for server builds (`load_server.go`), and provides a stub for client builds (`load_client.go`). The `CachedModel` struct now embeds `ServerModel`, ensuring clear separation between client and server logic. [[1]](diffhunk://#diff-437b759940704f5759191df0c80f7a758c1ff9ac431641533a6d0dc6ac89d140R1-R20) [[2]](diffhunk://#diff-2e8bfd650fc15f06f1ddb9f71e3c03497653ead260d0aeadb9deafdd8449e5c1R1-R9) [[3]](diffhunk://#diff-0521ca3ff831b816caffa9506ad6e1192e2eab2eb2804562b982440459163970L29-L36)
- Updated model loading logic to initialize the embedded `ServerModel` in `CachedModel`, ensuring proper encapsulation of model handles and thread safety for server builds.

**Token type simplification:**
- Replaced all uses of `llamacpp.Token` with a new `Token` type alias for `int32`, simplifying token handling in the schema and making it easier to use in both client and server contexts. [[1]](diffhunk://#diff-ab02df12d8c547bfa7b1538611525e25fb876a6d6fda923d049d564925bac9c6L3-R4) [[2]](diffhunk://#diff-ab02df12d8c547bfa7b1538611525e25fb876a6d6fda923d049d564925bac9c6L21-R25) [[3]](diffhunk://#diff-6133193ae1e7fa2ffc454c44ec9bb1dff7c7f9f5a6176008041be8dd8d8cd9d7L59-R58)

**Other improvements:**
- Added a `String()` method to `ModelRuntime` for easier debugging and logging.
- Cleaned up unused imports and code related to the old token and model handle management in several files. [[1]](diffhunk://#diff-0521ca3ff831b816caffa9506ad6e1192e2eab2eb2804562b982440459163970L4-L8) [[2]](diffhunk://#diff-6133193ae1e7fa2ffc454c44ec9bb1dff7c7f9f5a6176008041be8dd8d8cd9d7L10) [[3]](diffhunk://#diff-233213fe6abbbbe8e320f4be6dc3804a49a376496e65ec2ac81dd68489a98724L7)