### PR TITLE
Updated perimissions

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,94 +1,97 @@
 name: Build CLI Commands
 
 on:
-    push:
-        tags:
-            - "v*"
-    workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
-    build:
-        name: Build gollama
-        runs-on: ${{ matrix.os }}
-        strategy:
-            matrix:
-                include:
-                    - os: macos-latest
-                      arch: arm64
-                      goos: darwin
-                      goarch: arm64
-                    - os: ubuntu-24.04-arm
-                      arch: arm64
-                      goos: linux
-                      goarch: arm64
-                    - os: ubuntu-latest
-                      arch: amd64
-                      goos: linux
-                      goarch: amd64
-                    - os: windows-latest
-                      arch: amd64
-                      goos: windows
-                      goarch: amd64
+  build:
+    name: Build gollama
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            arch: arm64
+            goos: darwin
+            goarch: arm64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+            goos: linux
+            goarch: arm64
+          - os: ubuntu-latest
+            arch: amd64
+            goos: linux
+            goarch: amd64
+          - os: windows-latest
+            arch: amd64
+            goos: windows
+            goarch: amd64
 
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
-              with:
-                  submodules: recursive
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
-            - name: Set up Go
-              uses: actions/setup-go@v5
-              with:
-                  go-version: "1.25"
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
 
-            - name: Build gollama-client (Unix)
-              if: matrix.goos != 'windows'
-              env:
-                  GOOS: ${{ matrix.goos }}
-                  GOARCH: ${{ matrix.goarch }}
-              run: make gollama-client
+      - name: Build gollama-client (Unix)
+        if: matrix.goos != 'windows'
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: make gollama-client
 
-            - name: Build gollama-client (Windows)
-              if: matrix.goos == 'windows'
-              env:
-                  GOOS: ${{ matrix.goos }}
-                  GOARCH: ${{ matrix.goarch }}
-              shell: bash
-              run: |
-                  mkdir -p build
-                  go build -ldflags "-s -w" -tags client -o build/gollama.exe ./cmd/gollama
+      - name: Build gollama-client (Windows)
+        if: matrix.goos == 'windows'
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        shell: bash
+        run: |
+          mkdir -p build
+          go build -ldflags "-s -w" -tags client -o build/gollama.exe ./cmd/gollama
 
-            - name: Rename binary for release
-              shell: bash
-              run: |
-                  if [ "${{ matrix.goos }}" = "windows" ]; then
-                    mv build/gollama.exe build/gollama-${{ matrix.goos }}-${{ matrix.goarch }}.exe
-                  else
-                    mv build/gollama build/gollama-${{ matrix.goos }}-${{ matrix.goarch }}
-                  fi
-            - name: Upload artifact
-              uses: actions/upload-artifact@v4
-              with:
-                  name: gollama-${{ matrix.goos }}-${{ matrix.goarch }}
-                  path: build/gollama-${{ matrix.goos }}-${{ matrix.goarch }}*
+      - name: Rename binary for release
+        shell: bash
+        run: |
+          if [ "${{ matrix.goos }}" = "windows" ]; then
+            mv build/gollama.exe build/gollama-${{ matrix.goos }}-${{ matrix.goarch }}.exe
+          else
+            mv build/gollama build/gollama-${{ matrix.goos }}-${{ matrix.goarch }}
+          fi
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gollama-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: build/gollama-${{ matrix.goos }}-${{ matrix.goarch }}*
 
-    release:
-        name: Create Release
-        needs: build
-        runs-on: ubuntu-latest
-        if: startsWith(github.ref, 'refs/tags/')
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
 
-        steps:
-            - name: Download all artifacts
-              uses: actions/download-artifact@v4
-              with:
-                  path: ./artifacts
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts
 
-            - name: Create Release
-              uses: softprops/action-gh-release@v1
-              with:
-                  files: ./artifacts/**/*
-                  draft: false
-                  prerelease: false
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ./artifacts/**/*
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a small but important change to the GitHub Actions workflow configuration. It adds explicit permissions for the workflow to write to repository contents, which is necessary for certain actions that modify or upload files.

- GitHub Actions workflow configuration:
  * [`.github/workflows/cli.yml`](diffhunk://#diff-302cf6f60da3e4f2ef11792a8bcf7b39c384c4c0e4e065b575e0aaf7d5fa5c79R9-R11): Added `permissions: contents: write` to allow the workflow to write to repository contents.