### PR TITLE
Small fixes

### DIFF
--- a/sys/llamacpp/generate_cuda.go
+++ b/sys/llamacpp/generate_cuda.go
@@ -7,5 +7,6 @@ package llamacpp
 
 /*
 #cgo pkg-config: libllama-cuda cuda-12.6 cublas-12.6 cudart-12.6
+#cgo LDFLAGS: -L/usr/local/cuda/lib64/stubs -L/usr/local/cuda/targets/aarch64-linux/lib/stubs -L/usr/local/cuda/targets/x86_64-linux/lib/stubs
 */
 import "C"


### PR DESCRIPTION
This pull request introduces improvements to how standard input (stdin) is handled for the chat command and updates CUDA linker flags for better compatibility. The main changes are grouped as follows:

**Chat Command Input Handling:**

* Added a new `stdinHasData` function to detect if stdin is piped or redirected, improving how the chat command determines whether to read the system prompt from stdin or arguments. Now, the system prompt is only read from stdin if stdin is not already being used for chat messages. (`cmd/gollama/chat.go`) [[1]](diffhunk://#diff-535739601acbe7b8cdbd877c5fe0d4ee53ef20e8fac1e4534e40fbe86f4f0ba8L51-R54) [[2]](diffhunk://#diff-535739601acbe7b8cdbd877c5fe0d4ee53ef20e8fac1e4534e40fbe86f4f0ba8R219-R227)

**CUDA Linker Flags:**

* Updated the cgo linker flags in `generate_cuda.go` to include additional CUDA stub library paths, enhancing compatibility across different CUDA installations and architectures. (`sys/llamacpp/generate_cuda.go`)