### PR TITLE
Updated docker

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -9,6 +9,11 @@ on:
                 required: true
                 default: "latest"
                 type: string
+
+permissions:
+    contents: read
+    packages: write
+
 jobs:
     var:
         name: Set variables


### PR DESCRIPTION
This pull request makes a minor update to the `.github/workflows/docker.yaml` file to explicitly set permissions for the GitHub Actions workflow. The change ensures that the workflow has read access to repository contents and write access to GitHub Packages.

* Set `permissions` for the workflow to allow `contents: read` and `packages: write` in `.github/workflows/docker.yaml`